### PR TITLE
Require only `actiontext` in gemspec dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,37 +2,12 @@ PATH
   remote: .
   specs:
     mobility-actiontext (0.4.0)
+      actiontext (>= 6.0)
       mobility (~> 1.2)
-      rails (>= 6.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    actioncable (7.0.1)
-      actionpack (= 7.0.1)
-      activesupport (= 7.0.1)
-      nio4r (~> 2.0)
-      websocket-driver (>= 0.6.1)
-    actionmailbox (7.0.1)
-      actionpack (= 7.0.1)
-      activejob (= 7.0.1)
-      activerecord (= 7.0.1)
-      activestorage (= 7.0.1)
-      activesupport (= 7.0.1)
-      mail (>= 2.7.1)
-      net-imap
-      net-pop
-      net-smtp
-    actionmailer (7.0.1)
-      actionpack (= 7.0.1)
-      actionview (= 7.0.1)
-      activejob (= 7.0.1)
-      activesupport (= 7.0.1)
-      mail (~> 2.5, >= 2.5.4)
-      net-imap
-      net-pop
-      net-smtp
-      rails-dom-testing (~> 2.0)
     actionpack (7.0.1)
       actionview (= 7.0.1)
       activesupport (= 7.0.1)
@@ -76,41 +51,20 @@ GEM
     builder (3.2.4)
     concurrent-ruby (1.1.9)
     crass (1.0.6)
-    digest (3.1.0)
     erubi (1.10.0)
     globalid (1.0.0)
       activesupport (>= 5.0)
     i18n (1.8.11)
       concurrent-ruby (~> 1.0)
-    io-wait (0.2.1)
     loofah (2.13.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    mail (2.7.1)
-      mini_mime (>= 0.1.1)
     marcel (1.0.2)
-    method_source (1.0.0)
     mini_mime (1.1.2)
     minitest (5.15.0)
     mobility (1.2.5)
       i18n (>= 0.6.10, < 2)
       request_store (~> 1.0)
-    net-imap (0.2.3)
-      digest
-      net-protocol
-      strscan
-    net-pop (0.1.1)
-      digest
-      net-protocol
-      timeout
-    net-protocol (0.1.2)
-      io-wait
-      timeout
-    net-smtp (0.3.1)
-      digest
-      net-protocol
-      timeout
-    nio4r (2.5.8)
     nokogiri (1.13.1-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.13.1-x86_64-linux)
@@ -119,48 +73,19 @@ GEM
     rack (2.2.3)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
-    rails (7.0.1)
-      actioncable (= 7.0.1)
-      actionmailbox (= 7.0.1)
-      actionmailer (= 7.0.1)
-      actionpack (= 7.0.1)
-      actiontext (= 7.0.1)
-      actionview (= 7.0.1)
-      activejob (= 7.0.1)
-      activemodel (= 7.0.1)
-      activerecord (= 7.0.1)
-      activestorage (= 7.0.1)
-      activesupport (= 7.0.1)
-      bundler (>= 1.15.0)
-      railties (= 7.0.1)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.4.2)
       loofah (~> 2.3)
-    railties (7.0.1)
-      actionpack (= 7.0.1)
-      activesupport (= 7.0.1)
-      method_source
-      rake (>= 12.2)
-      thor (~> 1.0)
-      zeitwerk (~> 2.5)
-    rake (13.0.6)
     request_store (1.5.0)
       rack (>= 1.4)
     sqlite3 (1.4.2)
-    strscan (3.0.1)
-    thor (1.2.1)
-    timeout (0.2.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
-    websocket-driver (0.7.5)
-      websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.5)
-    zeitwerk (2.5.3)
 
 PLATFORMS
-  x86_64-darwin-20
+  x86_64-darwin
   x86_64-linux
 
 DEPENDENCIES

--- a/mobility-actiontext.gemspec
+++ b/mobility-actiontext.gemspec
@@ -26,8 +26,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.add_dependency 'actiontext', '>= 6.0'
   spec.add_dependency 'mobility', '~> 1.2'
-  spec.add_dependency 'rails', '>= 6.0'
 
   spec.add_development_dependency 'sqlite3', '~> 1.4'
 end

--- a/test_app/Gemfile.lock
+++ b/test_app/Gemfile.lock
@@ -2,8 +2,8 @@ PATH
   remote: ..
   specs:
     mobility-actiontext (0.4.0)
+      actiontext (>= 6.0)
       mobility (~> 1.2)
-      rails (>= 6.0)
 
 GEM
   remote: https://rubygems.org/
@@ -202,7 +202,7 @@ GEM
     zeitwerk (2.5.3)
 
 PLATFORMS
-  x86_64-darwin-20
+  x86_64-darwin
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
This PR fixes #19.

To minimize the number of Rails gems required, the gemspec now only list `actiontext` in addition to `mobility`.

I manually tested the change on a couple of projects depending only on a subset of Rails frameworks, and everything worked fine.