### PR TITLE
make eager loading single translation work

### DIFF
--- a/lib/mobility/backends/action_text.rb
+++ b/lib/mobility/backends/action_text.rb
@@ -28,6 +28,12 @@ module Mobility
       # override to return record instead of value
       def read(locale, **options)
         return super if self.options[:plain]
+
+        if model.association_cached?("rich_text_#{attribute}")
+          eager_loaded = model.public_send("rich_text_#{attribute}")
+          return eager_loaded if eager_loaded.locale == locale.to_s
+        end
+
         translation_for(locale, **options)
       end
 

--- a/test_app/test/mobility_action_text_test.rb
+++ b/test_app/test/mobility_action_text_test.rb
@@ -100,9 +100,13 @@ module Mobility
 
       assert_no_queries do
         assert_equal 'Hello world!', post.content.to_plain_text
-
-        skip('FIXME: this should execute no queries')
       end
+    end
+
+    test 'correct translation is returned if single translation for different locale was eager loaded' do
+      post = assert_queries(2) { Mobility.with_locale(:en) { Post.with_rich_text_content.last } }
+
+      assert_equal 'Bonjour le monde !', Mobility.with_locale(:fr) { post.content }.to_plain_text
     end
 
     test 'post content is eager loaded with all rich text' do
@@ -111,6 +115,12 @@ module Mobility
       assert_no_queries do
         assert_equal 'Hello world!', post.content.to_plain_text
       end
+    end
+
+    test 'correct translation is returned if all translations for different locale were eager loaded' do
+      post = assert_queries(2) { Mobility.with_locale(:en) { Post.with_all_rich_text.last } }
+
+      assert_equal 'Bonjour le monde !', Mobility.with_locale(:fr) { post.content }.to_plain_text
     end
 
     test 'post non_i18n_content is eager loaded with all rich text' do


### PR DESCRIPTION
Since mobility's key value store [loads all translations][1] we check if our is already eager loaded by using [association_cached?][2] before and return it if the locale matches.

fixes #18

[1]: https://github.com/shioyama/mobility/blob/4bf96b713991d5cf379aa6caeae2a3c448c73302/lib/mobility/backends/active_record/key_value.rb#L226
[2]: https://github.com/rails/rails/blob/75a9e1be75769ae633a938d81d51e06852a69ea3/activerecord/lib/active_record/associations.rb#L311