### PR TITLE
Add rich text associations for each locale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Mobility Action Text Changelog
 
+### Unreleased
+- Add rich text associations for each locale ([#25](https://github.com/sedubois/mobility-actiontext/pull/25)).
+
 ### 1.0.0 (2022-02-28)
 - Fix eager loading of single translation using `with_rich_text_#{name}` ([#24](https://github.com/sedubois/mobility-actiontext/pull/24)).
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,15 @@ This is done through the `Mobility::Backends::ActionText::Translation` model ext
 
 ## Development
 
-After checking out the repo, run `bundle install` to install dependencies. Then, run `cd test_app && bundle exec rails test` to run the tests.
+After checking out the repo, run `bundle install` to install dependencies.
+
+Execute tests by running:
+
+```sh
+cd test_app
+bundle install
+bundle exec rails test
+```
 
 To release a new version, update `lib/mobility/action_text/version.rb` and `CHANGELOG.md`, run `bundle && cd test_app && bundle`, commit, then run `bundle exec rake release`. This will create a git tag for the version, push git commits and the created tag, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 
@@ -88,4 +96,3 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/sedubo
 ## License
 
 The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
- 

--- a/lib/mobility/backends/action_text.rb
+++ b/lib/mobility/backends/action_text.rb
@@ -83,6 +83,11 @@ module Mobility
           has_one :"rich_text_#{name}", -> { where(name: name, locale: Mobility.locale) },
                   class_name: 'Mobility::Backends::ActionText::RichTextTranslation',
                   as: :record, inverse_of: :record, autosave: true, dependent: :destroy
+          Mobility.available_locales.each do |locale|
+            has_one :"rich_text_#{name}_#{locale}", -> { where(name: name, locale: locale) },
+                    class_name: 'Mobility::Backends::ActionText::RichTextTranslation',
+                    as: :record, inverse_of: :record, autosave: true, dependent: :destroy
+          end
           scope :"with_rich_text_#{name}", -> { includes("rich_text_#{name}") }
           scope :"with_rich_text_#{name}_and_embeds",
                 -> { includes("rich_text_#{name}": { embeds_attachments: :blob }) }

--- a/test_app/test/mobility_action_text_test.rb
+++ b/test_app/test/mobility_action_text_test.rb
@@ -46,13 +46,31 @@ module Mobility
       assert_equal 'Post Title', post.title
     end
 
-    test 'post has rich text content' do
+    test 'post has rich text content association' do
       post = posts(:one)
 
       assert_instance_of Mobility::Backends::ActionText::RichTextTranslation, post.rich_text_content
       assert_equal <<~HTML, post.content.to_s
         <div class="trix-content">
           <h1>Hello world!</h1>
+        </div>
+      HTML
+    end
+
+    test 'post has rich text content associations for each locale' do
+      post = posts(:one)
+
+      assert_instance_of Mobility::Backends::ActionText::RichTextTranslation, post.rich_text_content_en
+      assert_equal <<~HTML, post.rich_text_content_en.to_s
+      <div class="trix-content">
+        <h1>Hello world!</h1>
+      </div>
+      HTML
+
+      assert_instance_of Mobility::Backends::ActionText::RichTextTranslation, post.rich_text_content_fr
+      assert_equal <<~HTML, post.rich_text_content_fr.to_s
+        <div class="trix-content">
+          <h1>Bonjour le monde !</h1>
         </div>
       HTML
     end


### PR DESCRIPTION
When working with the Gem, I noticed that (given a `translates :content`), there was a `rich_text_content` association, which yields the associated model for the content in the current language. However, sometimes, not the current, but a specific translation is required. I therefore added new associations for each locale, e.g. `rich_text_content_en` and `rich_text_content_fr`.